### PR TITLE
Removes the example servers as bind is required

### DIFF
--- a/haproxy/default.toml
+++ b/haproxy/default.toml
@@ -13,13 +13,3 @@ port = 9000
 user = "admin"
 password = "password"
 uri = "/haproxy-stats"
-
-[[server]]
-name = "first"
-host_or_ip = "172.17.0.3"
-port = "8000"
-
-[[server]]
-name = "second"
-host_or_ip = "172.17.0.4"
-port = "8000"


### PR DESCRIPTION
When copying over the default values from core/haproxy I left these values in
place. However, they are never used.

Signed-off-by: Franklin Webber <franklin@chef.io>