### PR TITLE
Included creation of user & group 'hab' in init script. Stop gap as '…

### DIFF
--- a/webapp/hooks/init
+++ b/webapp/hooks/init
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+addgroup hab
+adduser --disabled-password --ingroup hab hab
+
 chmod 755 {{pkg.svc_data_path}}
 
 mkdir -p {{pkg.svc_data_path}}/htdocs


### PR DESCRIPTION
…hab' user not being created in docker export.