### PR TITLE
Update docker-compose to include `HAB_LICENSE` for Habitat 0.81 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ hab pkg export docker results/learn-chef-haproxy-1.6.11-20180105200724-x86_64-
 ## Run
 
 ```
-$ docker-compose up -d
+$ HAB_LICENSE=accept-no-persist docker-compose up -d
 $ curl localhost:8000/cgi-bin/hello-world
 $ docker-compose down
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,19 @@
 version: '3'
 services:
   web-1:
+    environment:
+      - HAB_LICENSE
     image: $HAB_ORIGIN/webapp
   web-2:
+    environment:
+      - HAB_LICENSE
     image: $HAB_ORIGIN/webapp
     command: --peer web-1
     depends_on:
       - web-1
   load-balancer:
+    environment:
+      - HAB_LICENSE
     image: $HAB_ORIGIN/haproxy
     command: --peer web-2
              --bind backend:webapp.default


### PR DESCRIPTION
This commit adds the `HAB_LICENSE` environment variable [1] to the
docker-compose.yml and README.md to resolve the issue experienced with
"Try Habitat" learn.chef.io module [2] as documented on the forum [3]

[1] https://forums.habitat.sh/t/habitat-0-80-0-released/1087
[2] https://learn.chef.io/modules/try-habitat#/
[3]
https://forums.habitat.sh/t/launching-docker-containers-requires-chef-license-acceptance/1108

Signed-off-by: qubitrenegade <qubitrenegade@gmail.com>